### PR TITLE
Add fitness validation in generators

### DIFF
--- a/diffevo/generator.py
+++ b/diffevo/generator.py
@@ -118,6 +118,8 @@ class BayesianGenerator:
     """
     def __init__(self, x, fitness, alpha, density='uniform', h=0.1):
         self.x = x
+        if torch.any(fitness < 0):
+            raise ValueError('fitness_score must be non-negative')
         self.fitness = fitness
         self.alpha, self.alpha_past = alpha
         self.estimator = BayesianEstimator(self.x, self.fitness, self.alpha, density=density, h=h)
@@ -140,6 +142,8 @@ class LatentBayesianGenerator(BayesianGenerator):
         # density and h are legacy options kept for backward compatibility
         self.x = x
         self.latent = latent
+        if torch.any(fitness < 0):
+            raise ValueError('fitness_score must be non-negative')
         self.fitness = fitness
         self.alpha, self.alpha_past = alpha
         self.estimator = LatentBayesianEstimator(self.x, self.latent, self.fitness, self.alpha, density=density, h=h)


### PR DESCRIPTION
## Summary
- add non-negative fitness validation to `BayesianGenerator` and `LatentBayesianGenerator`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850aeb9016c832a8f4c6c8c67c08f74