### PR TITLE
Fix generator doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ for t, alpha in scheduler:
     x = generator(noise=0)
 ```
 
+The generator requires fitness values to be non-negative. If your objective
+returns negative values, please apply a mapping (see `diffevo.fitnessmapping`)
+to convert them before calling the generator.
+
 The following are two evolution trajectories of different fitness functions.
 
 ## Advanced Usage

--- a/diffevo/generator.py
+++ b/diffevo/generator.py
@@ -119,7 +119,7 @@ class BayesianGenerator:
     def __init__(self, x, fitness, alpha, density='uniform', h=0.1):
         self.x = x
         if torch.any(fitness < 0):
-            raise ValueError('fitness_score must be non-negative')
+            raise ValueError('fitness must be non-negative')
         self.fitness = fitness
         self.alpha, self.alpha_past = alpha
         self.estimator = BayesianEstimator(self.x, self.fitness, self.alpha, density=density, h=h)
@@ -143,7 +143,7 @@ class LatentBayesianGenerator(BayesianGenerator):
         self.x = x
         self.latent = latent
         if torch.any(fitness < 0):
-            raise ValueError('fitness_score must be non-negative')
+            raise ValueError('fitness must be non-negative')
         self.fitness = fitness
         self.alpha, self.alpha_past = alpha
         self.estimator = LatentBayesianEstimator(self.x, self.latent, self.fitness, self.alpha, density=density, h=h)


### PR DESCRIPTION
## Summary
- clarify that fitness needs to be non-negative
- fix error messages in generators

## Testing
- `grep -n "non-negative" README.md`


------
https://chatgpt.com/codex/tasks/task_e_6850afe3ac38832a87aec12805f740fd